### PR TITLE
docs: release notes

### DIFF
--- a/releases/v0.1.7.md
+++ b/releases/v0.1.7.md
@@ -1,0 +1,9 @@
+k6exec `v0.1.7` is here 🎉!
+
+This is an internal maintenance release.
+
+**New features**:
+
+- Added support for `inspect` command.
+- Added k6 alias for k6exec in docker image.
+- Use https://registry.k6.io/catalog.json as default catalog.


### PR DESCRIPTION
k6exec `v0.1.7` is here 🎉!

This is an internal maintenance release.

**New features**:

- Added support for `inspect` command.
- Added k6 alias for k6exec in docker image.
- Use https://registry.k6.io/catalog.json as default catalog.
