### PR TITLE
fix subcommand flags handling

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+type argsKey struct{}
+
+// SetArgs set arguments for cmd command and store the args in the context.
+func SetArgs(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cmd.SetContext(context.WithValue(ctx, argsKey{}, args))
+
+	cmd.SetArgs(args)
+}
+
+func getArgs(cmd *cobra.Command) []string {
+	ctx := cmd.Context()
+	if ctx == nil {
+		return nil
+	}
+
+	value := ctx.Value(argsKey{})
+	if value == nil {
+		return nil
+	}
+
+	args, ok := value.([]string)
+	if !ok {
+		return nil
+	}
+
+	for idx := range args {
+		if args[idx] == cmd.Name() {
+			return args[idx+1:]
+		}
+	}
+
+	return nil
+}

--- a/cmd/k6exec/main.go
+++ b/cmd/k6exec/main.go
@@ -4,7 +4,6 @@ package main
 import (
 	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/grafana/k6exec/cmd"
 	sloglogrus "github.com/samber/slog-logrus/v2"
@@ -36,17 +35,16 @@ func main() {
 }
 
 func newCmd(args []string, levelVar *slog.LevelVar) *cobra.Command {
-	cmd := cmd.New(levelVar)
-	cmd.Use = strings.ReplaceAll(cmd.Use, "exec", appname)
-	cmd.Version = version
+	root := cmd.New(levelVar)
+	root.Version = version
 
 	if len(args) == 1 && (args[0] == "-h" || args[0] == "--help") {
 		args[0] = "help"
 	}
 
-	cmd.SetArgs(args)
+	cmd.SetArgs(root, args)
 
-	return cmd
+	return root
 }
 
 func runCmd(cmd *cobra.Command) {

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -114,7 +114,11 @@ func (s *state) preRunE(sub *cobra.Command, args []string) error {
 		cmdargs = append(cmdargs, "--no-color")
 	}
 
-	cmdargs = append(cmdargs, args...)
+	if subargs := getArgs(sub); subargs != nil {
+		cmdargs = append(cmdargs, subargs...)
+	} else {
+		cmdargs = append(cmdargs, args...)
+	}
 
 	cmd, err := k6exec.Command(context.Background(), cmdargs, deps, &s.Options)
 	if err != nil {

--- a/releases/v0.1.8.md
+++ b/releases/v0.1.8.md
@@ -1,0 +1,8 @@
+k6exec `v0.1.8` is here 🎉!
+
+This is an internal bugfix release.
+
+**Fix subcommand flags handling**
+
+Passing subcommand specific flags was not possible, k6exec swallowed these flags.
+This has been fixed.


### PR DESCRIPTION
**Fix subcommand flags handling**

Passing subcommand specific flags was not possible, k6exec swallowed these flags.
This has been fixed.
